### PR TITLE
Galaxy_tags is attribute of galaxy_info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,5 +8,5 @@ galaxy_info:
       - 5
       - 6
 
-galaxy_tags: [sumologic]
+  galaxy_tags: [sumologic]
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,6 +7,7 @@ galaxy_info:
      versions:
       - 5
       - 6
-
-  galaxy_tags: [sumologic]
+      - 7
+  galaxy_tags:
+    - sumologic
 dependencies: []


### PR DESCRIPTION
This will fix the error to run role: 
ERROR! 'galaxy_tags' is not a valid attribute for a RoleMetadata

The error appears to have been in '/root/.ansible/roles/sumologic-agent/meta/main.yml': line 1, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


galaxy_info:
^ here